### PR TITLE
dashboard detail page + version uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-stub-context": "^0.3.0",
     "react-tools": "^0.13.3",
     "redux-devtools": "^2.1.0",
-    "sherlocked": "^0.14.0",
+    "sherlocked": "^1.0.2",
     "sinon": "^1.14.1",
     "stylus": "^0.50.0",
     "webpack": "^1.12.0",

--- a/sherlocked.js
+++ b/sherlocked.js
@@ -18,7 +18,12 @@ function desktop(client, path) {
 require('sherlocked')
 
 .investigate('Firefox OS Add-on Dashboard', function(client) {
-  return desktop(client, 'addon/')
+  return desktop(client, 'addon/dashboard/')
+    .waitForExist('main', 60000);
+})
+
+.investigate('Firefox OS Add-on Dashboard Detail', function(client) {
+  return desktop(client, 'addon/dashboard/test-addon')
     .waitForExist('main', 60000);
 })
 

--- a/src/media/js/addon/actions/submitVersion.js
+++ b/src/media/js/addon/actions/submitVersion.js
@@ -1,10 +1,13 @@
 /*
-  Add-on validation and submission actions.
+  Add-on version validation and submission actions.
 
-  1. Upload a ZIP, get a validation ID.
-  2. Poll the validation API using the given ID to get processing status.
-  3. Once validation passes, ping the API with the validation ID to create the
-     add-on and finish the submission process.
+  Adapted from actions/submit.js. It was difficult to completely reuse the
+  add-on submission action code since we want to dispatch different action
+  constants. Also, the route for versions is slightly different, we would
+  have to pass down arguments down the chain all the way to the end to
+  appropriately multiplex it.
+
+  TODO: refactor out the pieces we can from actions/submit.js for reuse.
 */
 'use strict';
 import {createAction} from 'redux-actions';
@@ -13,30 +16,33 @@ import Url from 'urlgray';
 import urlJoin from 'url-join';
 
 
-export const VALIDATION_BEGIN = 'SUBMISSION_ADDON__VALIDATION_BEGIN';
+export const VALIDATION_BEGIN = 'ADDON_SUBMIT_VERSION__VALIDATION_BEGIN';
 const validationBegin = createAction(VALIDATION_BEGIN);
 
 // For when the add-on upload has started processing.
-export const VALIDATION_PENDING = 'SUBMISSION_ADDON__VALIDATION_PENDING';
+export const VALIDATION_PENDING = 'ADDON_SUBMIT_VERSION__VALIDATION_PENDING';
 const validationPending = createAction(VALIDATION_PENDING);
 
 // For when the add-on upload has finished validation.
-export const VALIDATION_PASS = 'SUBMISSION_ADDON__VALIDATION_PASS';
+export const VALIDATION_PASS = 'ADDON_SUBMIT_VERSION__VALIDATION_PASS';
 const validationPassed = createAction(VALIDATION_PASS);
 
-export const VALIDATION_FAIL = 'SUBMISSION_ADDON__VALIDATION_FAIL';
+export const VALIDATION_FAIL = 'ADDON_SUBMIT_VERSION__VALIDATION_FAIL';
 const validationFail = createAction(VALIDATION_FAIL);
 
-export const SUBMIT_OK = 'SUBMISSION_ADDON__SUBMIT_OK';
+export const SUBMIT_OK = 'ADDON_SUBMIT_VERSION__SUBMIT_OK';
 const submitOk = createAction(SUBMIT_OK);
 
-export const SUBMIT_ERROR = 'SUBMISSION_ADDON__SUBMIT_ERROR';
+export const SUBMIT_ERROR = 'ADDON_SUBMIT_VERSION__SUBMIT_ERROR';
 const submitError = createAction(SUBMIT_ERROR);
 
 
-export function validate(fileData) {
+export function submitVersion(fileData, addonSlug) {
   /*
     Upload add-on .zip file for validation.
+
+    addonSlug -- will be passed down all the way from validation, polling, to
+                 actual version creation.
   */
   return (dispatch, getState) => {
     const apiArgs = getState().apiArgs || {};
@@ -57,7 +63,7 @@ export function validate(fileData) {
         dispatch(validationPending(res.body.id));
 
         // Take further action by polling.
-        dispatch(pollValidator(res.body.id));
+        dispatch(pollValidator(res.body.id, addonSlug));
       }, err => {
         dispatch(validationFail(JSON.parse(err.response.text).detail));
       });
@@ -65,7 +71,7 @@ export function validate(fileData) {
 }
 
 
-export function pollValidator(validationId) {
+export function pollValidator(validationId, addonSlug) {
   /*
     Poll add-on's validation detail endpoint to wait until validation has
     processed.
@@ -86,7 +92,7 @@ export function pollValidator(validationId) {
             clearInterval(pollValidatorInterval);
 
             if (res.body.valid) {
-              dispatch(create());
+              dispatch(createVersion(addonSlug));
             } else {
               dispatch(validationFail(res.body.validation));
             }
@@ -102,23 +108,24 @@ export function pollValidator(validationId) {
 }
 
 
-export function create() {
+export function createVersion(addonSlug) {
   /*
-    Finish add-on submission process.
+    Finish add-on version submission process.
   */
   return (dispatch, getState) => {
     const apiArgs = getState().apiArgs || {};
-    const createUrl = Url(
-      urlJoin(process.env.MKT_API_ROOT, 'extensions/extension/')
+    const createVersionUrl = Url(
+      urlJoin(process.env.MKT_API_ROOT, 'extensions/extension/',
+              addonSlug, 'versions/')
     ).q(apiArgs);
 
     req
-      .post(createUrl)
-      .send({validation_id: getState().addonSubmit.validationId})
+      .post(createVersionUrl)
+      .send({validation_id: getState().addonSubmitVersion.validationId})
       .then(res => {
         dispatch(submitOk(res.body));
       }, err => {
-        dispatch(submitError(res.body));
+        dispatch(submitError(err.response.body));
       });
   };
 }

--- a/src/media/js/addon/components/addon.js
+++ b/src/media/js/addon/components/addon.js
@@ -9,6 +9,7 @@ export class AddonListing extends React.Component {
   static propTypes = {
     addons: React.PropTypes.array.isRequired,
     showReviewActions: React.PropTypes.bool,
+    showVersions: React.PropTypes.bool,
   };
 
   render() {
@@ -16,7 +17,7 @@ export class AddonListing extends React.Component {
       <ul className="addon-listing">
         {this.props.addons.map(addon =>
           <li>
-            <Addon {...this.props} {...addon} isListing={true}/>
+            <Addon {...this.props} {...addon}/>
           </li>
         )}
         {this.props.addons.length === 0 && <p>No add-ons.</p>}
@@ -27,7 +28,7 @@ export class AddonListing extends React.Component {
 
 
 export class Addon extends React.Component {
-  static PropTypes = {
+  static propTypes = {
     description: React.PropTypes.string,
     latest_public_version: React.PropTypes.number,
     latest_version: React.PropTypes.number.isRequired,
@@ -35,18 +36,23 @@ export class Addon extends React.Component {
     name: React.PropTypes.string.isRequired,
     slug: React.PropTypes.string.isRequired,
 
-    isListing: React.PropTypes.bool,
+    linkTo: React.PropTypes.string,
     publish: React.PropTypes.func,
     reject: React.PropTypes.func,
     showReviewActions: React.PropTypes.bool,
+    showVersions: React.PropTypes.bool,
+  };
+
+  static defaultProps = {
+    showReviewActions: false,
+    showVersions: true,
   };
 
   renderName() {
-    if (this.props.isListing && this.props.showReviewActions) {
-      // Render a link to review detail page if part of review queue.
+    if (this.props.linkTo) {
+      // If `linkTo`, have the header link to a more detailed page.
       return (
-        <ReverseLink to="addon-review-detail"
-                     params={{slug: this.props.slug}}>
+        <ReverseLink to={this.props.linkTo} params={{slug: this.props.slug}}>
           <h2>{this.props.name}</h2>
         </ReverseLink>
       );
@@ -103,7 +109,7 @@ export class Addon extends React.Component {
           </di>
         }
 
-        {!this.props.isListing &&
+        {this.props.showVersions &&
           <VersionListing publish={this.props.publish}
                           reject={this.props.reject}
                           showReviewActions={this.props.showReviewActions}

--- a/src/media/js/addon/components/upload.js
+++ b/src/media/js/addon/components/upload.js
@@ -1,0 +1,83 @@
+/*
+  Dumb component for add-on uploads to share between add-on submission and
+  add-on version submission.
+*/
+import React from 'react';
+import FileReaderInput from 'react-file-reader-input';
+
+
+export default class AddonUpload extends React.Component {
+  /*
+    slug -- only used in new version submissions.
+  */
+  static contextTypes = {
+    router: React.PropTypes.object
+  };
+
+  static propTypes = {
+    isSubmitting: React.PropTypes.bool,
+    slug: React.PropTypes.string,
+    submit: React.PropTypes.func.isRequired,
+    validationErrorMessage: React.PropTypes.string
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.accept = [
+      'application/octet-stream',
+      'application/zip',
+      'application/x-zip',
+      'application/x-zip-compressed'
+    ].join(',');
+
+    this.state = {
+      fileData: null,
+      fileSize: null,
+      fileName: null
+    };
+  }
+
+  handleChange = (e, results) => {
+    const [result, file] = results[0];
+    this.setState({
+      fileData: result.target.result,
+      fileSize: result.loaded,
+      fileName: file.name
+    });
+  }
+
+  handleSubmit = e => {
+    e.preventDefault();
+    this.props.submit(this.state.fileData, this.props.slug);
+  }
+
+  render() {
+    return (
+      <div>
+        <form className="form-inline" onSubmit={this.handleSubmit}>
+          <label htmlFor="submission-addon--zip">Add-on ZIP File:</label>
+          <FileReaderInput as="buffer" accept=".zip"
+                           id="submission-addon--zip"
+                           onChange={this.handleChange}>
+            <div className="form-inline--file-input"
+                 data-file-input--has-data={!!this.state.fileName}>
+              {this.state.fileName ?
+               `${this.state.fileName} (${this.state.fileSize}KB)` :
+               'Select a File...'}
+            </div>
+          </FileReaderInput>
+          <button type="submit" disabled={this.props.isSubmitting}>
+            {this.props.isSubmitting ? 'Processing...' : 'Submit'}
+          </button>
+        </form>
+
+        {this.props.validationErrorMessage &&
+          <p className="form-msg--error">
+            {this.props.validationErrorMessage}
+          </p>
+        }
+      </div>
+    );
+  }
+}

--- a/src/media/js/addon/containers/__tests__/dashboardDetail.test.js
+++ b/src/media/js/addon/containers/__tests__/dashboardDetail.test.js
@@ -1,0 +1,20 @@
+import {AddonDashboardDetail} from '../dashboardDetail';
+
+
+describe('AddonDashboardDetail', () => {
+  jsdom();
+
+  const props = {
+    addon: addonFactory(),
+    slug: 'test-addon',
+    fetchAddon: () => {},
+    fetchVersions: () => {},
+  };
+
+  it('renders', () => {
+    const component = ReactDOMHelper.render(
+      <StubRouterProvider Component={AddonDashboardDetail} {...props}/>
+    );
+    assert.equal(ReactDOMHelper.queryClassAll(component, 'addon').length, 1);
+  });
+});

--- a/src/media/js/addon/containers/dashboard.js
+++ b/src/media/js/addon/containers/dashboard.js
@@ -30,7 +30,9 @@ export class AddonDashboard extends React.Component {
     return (
       <section>
         <PageHeader title="My Firefox OS Add-ons" subnav={<AddonSubnav/>}/>
-        <AddonListing addons={this.props.addons}/>
+        <AddonListing addons={this.props.addons}
+                      linkTo="addon-dashboard-detail"
+                      showVersions={false}/>
       </section>
     );
   }

--- a/src/media/js/addon/containers/dashboardDetail.js
+++ b/src/media/js/addon/containers/dashboardDetail.js
@@ -1,0 +1,58 @@
+/*
+  Dashboard page for a single add-on.
+
+  Lists the add-on's versions.
+  Allows uploading new versions.
+*/
+import React from 'react';
+import {connect} from 'react-redux';
+import {ReverseLink} from 'react-router-reverse';
+import {bindActionCreators} from 'redux';
+
+import {fetch as fetchAddon, fetchVersions} from '../actions/addon';
+import {Addon} from '../components/addon';
+import AddonSubnav from '../components/addonSubnav';
+import PageHeader from '../../site/components/pageHeader';
+
+
+export class AddonDashboardDetail extends React.Component {
+  static propTypes = {
+    addon: React.PropTypes.object,
+    fetchAddon: React.PropTypes.func.isRequired,
+    fetchVersions: React.PropTypes.func.isRequired,
+    slug: React.PropTypes.string.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    if (!this.props.addon) {
+      this.props.fetchAddon(this.props.slug);
+    }
+    this.props.fetchVersions(this.props.slug);
+  }
+
+  render() {
+    return (
+      <section>
+        <PageHeader
+          title={`Viewing Firefox OS Add-on: ${this.props.addon.name}`}
+          subnav={<AddonSubnav/>}/>
+
+        <Addon {...this.props.addon}/>
+      </section>
+    );
+  }
+};
+
+
+export default connect(
+  state => ({
+    addon: state.addonDashboard.addons[state.router.params.slug] || {},
+    slug: state.router.params.slug
+  }),
+  dispatch => bindActionCreators({
+    fetchAddon,
+    fetchVersions,
+  }, dispatch)
+)(AddonDashboardDetail);

--- a/src/media/js/addon/containers/dashboardDetail.js
+++ b/src/media/js/addon/containers/dashboardDetail.js
@@ -10,8 +10,10 @@ import {ReverseLink} from 'react-router-reverse';
 import {bindActionCreators} from 'redux';
 
 import {fetch as fetchAddon, fetchVersions} from '../actions/addon';
+import {submitVersion} from '../actions/submitVersion';
 import {Addon} from '../components/addon';
 import AddonSubnav from '../components/addonSubnav';
+import AddonUpload from '../components/upload';
 import PageHeader from '../../site/components/pageHeader';
 
 
@@ -21,18 +23,24 @@ export class AddonDashboardDetail extends React.Component {
     fetchAddon: React.PropTypes.func.isRequired,
     fetchVersions: React.PropTypes.func.isRequired,
     slug: React.PropTypes.string.isRequired,
+    submitVersion: React.PropTypes.func.isRequired,
   };
 
   constructor(props) {
     super(props);
-
-    if (!this.props.addon) {
-      this.props.fetchAddon(this.props.slug);
-    }
+    this.props.fetchAddon(this.props.slug);
     this.props.fetchVersions(this.props.slug);
   }
 
   render() {
+    if (!this.props.addon || !this.props.addon.slug) {
+      return (
+        <section>
+          <PageHeader title="Loading Firefox OS Add-on..."
+                      subnav={<AddonSubnav/>}/>
+        </section>
+      );
+    }
     return (
       <section>
         <PageHeader
@@ -40,6 +48,11 @@ export class AddonDashboardDetail extends React.Component {
           subnav={<AddonSubnav/>}/>
 
         <Addon {...this.props.addon}/>
+
+        <h3>Upload a New Version</h3>
+        <AddonUpload {...this.props.addonSubmitVersion}
+                     slug={this.props.slug}
+                     submit={this.props.submitVersion}/>
       </section>
     );
   }
@@ -48,11 +61,13 @@ export class AddonDashboardDetail extends React.Component {
 
 export default connect(
   state => ({
-    addon: state.addonDashboard.addons[state.router.params.slug] || {},
-    slug: state.router.params.slug
+    addon: state.addonDashboard.addons[state.router.params.slug],
+    addonSubmitVersion: state.addonSubmitVersion,
+    slug: state.router.params.slug,
   }),
   dispatch => bindActionCreators({
     fetchAddon,
     fetchVersions,
+    submitVersion
   }, dispatch)
 )(AddonDashboardDetail);

--- a/src/media/js/addon/containers/review.js
+++ b/src/media/js/addon/containers/review.js
@@ -34,9 +34,11 @@ export class AddonReview extends React.Component {
         <PageHeader title="Reviewing Firefox OS Add-ons"
                     subnav={<AddonSubnav/>}/>
         <AddonListing addons={this.props.addons}
+                      linkTo="addon-review-detail"
                       publish={this.props.publish}
                       reject={this.props.reject}
-                      showReviewActions={true}/>
+                      showReviewActions={true}
+                      showVersions={false}/>
       </section>
     );
   }

--- a/src/media/js/addon/containers/reviewDetail.js
+++ b/src/media/js/addon/containers/reviewDetail.js
@@ -27,14 +27,19 @@ export class AddonReviewDetail extends React.Component {
 
   constructor(props) {
     super(props);
-
-    if (!this.props.addon) {
-      this.props.fetchAddon(this.props.slug);
-    }
+    this.props.fetchAddon(this.props.slug);
     this.props.fetchVersions(this.props.slug);
   }
 
   render() {
+    if (!this.props.addon || !this.props.addon.slug) {
+      return (
+        <section>
+          <PageHeader title="Loading Firefox OS Add-on..."
+                      subnav={<AddonSubnav/>}/>
+        </section>
+      );
+    }
     return (
       <section>
         <PageHeader
@@ -52,7 +57,7 @@ export class AddonReviewDetail extends React.Component {
 
 export default connect(
   state => ({
-    addon: state.addonReviewDetail.addons[state.router.params.slug] || {},
+    addon: state.addonReviewDetail.addons[state.router.params.slug],
     slug: state.router.params.slug
   }),
   dispatch => bindActionCreators({

--- a/src/media/js/addon/containers/submit.js
+++ b/src/media/js/addon/containers/submit.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import {reverse} from 'react-router-reverse';
 import {bindActionCreators} from 'redux';
-import FileReaderInput from 'react-file-reader-input';
 import {connect} from 'react-redux';
 
-import {validate as submit} from '../actions/submit';
+import {submit} from '../actions/submit';
 import AddonSubnav from '../components/addonSubnav';
+import AddonUpload from '../components/upload';
 import PageHeader from '../../site/components/pageHeader';
 
 
@@ -20,22 +20,6 @@ export class AddonSubmit extends React.Component {
     validationErrorMessage: React.PropTypes.string
   };
 
-  constructor(props) {
-    super(props);
-
-    this.accept = [
-      'application/octet-stream',
-      'application/zip',
-      'application/x-zip',
-      'application/x-zip-compressed'
-    ].join(',');
-
-    this.state = {
-      fileData: null,
-      fileSize: null,
-      fileName: null
-    };
-  }
   componentWillReceiveProps(nextProps) {
     // TODO: once we move to React 0.14, dispatch redux-react-router's
     // transitionTo in add-on submission actions instead. Doesn't work in 0.13.
@@ -48,48 +32,14 @@ export class AddonSubmit extends React.Component {
     }
   }
 
-  handleChange = (e, results) => {
-    const [result, file] = results[0];
-    this.setState({
-      fileData: result.target.result,
-      fileSize: result.loaded,
-      fileName: file.name
-    });
-  }
-
-  handleSubmit = e => {
-    e.preventDefault();
-    this.props.submit(this.state.fileData);
-  }
-
   render() {
     return (
       <section>
         <PageHeader title="Submitting Firefox OS Add-ons"
                     subnav={<AddonSubnav/>}/>
 
-        <form className="form-inline" onSubmit={this.handleSubmit}>
-          <label htmlFor="submission-addon--zip">Add-on ZIP File:</label>
-          <FileReaderInput as="buffer" accept=".zip"
-                           id="submission-addon--zip"
-                           onChange={this.handleChange}>
-            <div className="form-inline--file-input"
-                 data-file-input--has-data={!!this.state.fileName}>
-              {this.state.fileName ?
-               `${this.state.fileName} (${this.state.fileSize}KB)` :
-               'Select a File...'}
-            </div>
-          </FileReaderInput>
-          <button type="submit" disabled={this.props.isSubmitting}>
-            {this.props.isSubmitting ? 'Processing...' : 'Submit'}
-          </button>
-        </form>
-
-        {this.props.validationErrorMessage &&
-          <p className="form-msg--error">
-            {this.props.validationErrorMessage}
-          </p>
-        }
+        <h3>Upload a Firefox OS Add-on</h3>
+        <AddonUpload {...this.props}/>
       </section>
     );
   }

--- a/src/media/js/addon/reducers/dashboard.js
+++ b/src/media/js/addon/reducers/dashboard.js
@@ -3,6 +3,7 @@
 */
 import _ from 'lodash';
 
+import * as addonActions from '../actions/addon';
 import * as dashboardActions from '../actions/dashboard';
 import * as submitActions from '../actions/submit';
 
@@ -15,6 +16,31 @@ const initialState = {
 
 export default function addonDashboardReducer(state=initialState, action) {
   switch (action.type) {
+    case addonActions.FETCH_OK: {
+      /* Store single add-on. */
+      const newState = _.cloneDeep(state);
+      newState.addons[action.payload.slug] = action.payload;
+      return newState;
+    }
+
+    case addonActions.FETCH_VERSIONS_OK: {
+      // Attach versions to their respective addon.
+      const newState = _.cloneDeep(state);
+
+      // Create add-on if it doesn't exist, just in case.
+      if (!newState.addons[action.payload.addonSlug]) {
+        newState.addons[action.payload.addonSlug] = {};
+      }
+
+      // Store as an object keyed by version ID for easier lookups.
+      const addon = newState.addons[action.payload.addonSlug];
+      addon.versions = {};
+      action.payload.versions.forEach(version => {
+        addon.versions[version.id] = version;
+      });
+      return newState;
+    }
+
     case dashboardActions.FETCH_OK: {
       /* Set dashboards add-ons. */
       const newState = _.cloneDeep(state);

--- a/src/media/js/addon/reducers/submit.js
+++ b/src/media/js/addon/reducers/submit.js
@@ -1,7 +1,13 @@
 /*
-    Reducer for Firefox OS add-ons validation and submission process.
+  Reducer for add-on validation and submission process.
+
+  Also used for add-on version validation and submission. We have a helper
+  function that takes an action module to generate a reducer. Add-on actions
+  and add-on version actions dispatch the same actions, but with slightly
+  different action types. Thus, we need to differentiate them.
 */
 import * as submitActions from '../actions/submit';
+import * as submitVersionActions from '../actions/submitVersion';
 
 
 const initialState = {
@@ -11,34 +17,49 @@ const initialState = {
 };
 
 
-export default function addonSubmitReducer(state=initialState, action) {
-  switch (action.type) {
-    case submitActions.VALIDATION_BEGIN: {
-      return Object.assign({}, initialState, {
-        isSubmitting: true
-      });
-    }
+function createAddonSubmitReducer(actions) {
+  return function(state=initialState, action) {
+    switch (action.type) {
+      case actions.VALIDATION_BEGIN: {
+        return Object.assign({}, initialState, {
+          isSubmitting: true
+        });
+      }
 
-    case submitActions.VALIDATION_PENDING: {
-      return Object.assign({}, state, {
-        validationId: action.payload,
-      });
-    }
+      case actions.VALIDATION_PENDING: {
+        return Object.assign({}, state, {
+          validationId: action.payload,
+        });
+      }
 
-    case submitActions.VALIDATION_FAIL: {
-      return Object.assign({}, state, {
-        isSubmitting: false,
-        validationErrorMessage: action.payload,
-      });
-    }
+      case actions.VALIDATION_FAIL: {
+        return Object.assign({}, state, {
+          isSubmitting: false,
+          validationErrorMessage: action.payload,
+        });
+      }
 
-    case submitActions.SUBMIT_OK: {
-      // Reset once an add-on submission is complete.
-      return initialState;
-    }
+      case actions.SUBMIT_ERROR: {
+        return Object.assign({}, state, {
+          isSubmitting: false,
+          validationErrorMessage: action.payload,
+        });
+      }
 
-    default: {
-      return state;
+      case actions.SUBMIT_OK: {
+        // Reset once an add-on submission is complete.
+        return initialState;
+      }
+
+      default: {
+        return state;
+      }
     }
   }
 }
+
+
+export const addonSubmitReducer = createAddonSubmitReducer(
+  submitActions);
+export const addonSubmitVersionReducer = createAddonSubmitReducer(
+  submitVersionActions);

--- a/src/media/js/app.js
+++ b/src/media/js/app.js
@@ -14,6 +14,7 @@ import thunkMiddleware from 'redux-thunk';
 import {loginRequired} from './site/login';
 
 import AddonDashboard from './addon/containers/dashboard';
+import AddonDashboardDetail from './addon/containers/dashboardDetail';
 import AddonLanding from './addon/containers/landing';
 import AddonReview from './addon/containers/review';
 import AddonReviewDetail from './addon/containers/reviewDetail';
@@ -105,6 +106,8 @@ function renderRoutes() {
                                              'website_submitter'])}/>
             <Route name="addon-dashboard" path="/addon/dashboard/"
                    component={loginRequired(AddonDashboard, Login)}/>
+            <Route name="addon-dashboard-detail" path="/addon/dashboard/:slug"
+                   component={loginRequired(AddonDashboardDetail, Login)}/>
             <Route name="addon-review" path="/addon/review/"
                    component={loginRequired(AddonReview, Login,
                                             ['reviewer'])}/>

--- a/src/media/js/app.js
+++ b/src/media/js/app.js
@@ -1,3 +1,4 @@
+require('babel/polyfill');
 import React from 'react';
 import {Provider} from 'react-redux';
 import {Redirect, Route, Router} from 'react-router';
@@ -31,7 +32,10 @@ import WebsiteSubmit from './website/containers/submit';
 import addonDashboard from './addon/reducers/dashboard';
 import addonReview from './addon/reducers/review';
 import addonReviewDetail from './addon/reducers/reviewDetail';
-import addonSubmit from './addon/reducers/submit';
+import {addonSubmitReducer as
+        addonSubmit,
+        addonSubmitVersionReducer as
+        addonSubmitVersion} from './addon/reducers/submit';
 import apiArgs from './site/reducers/apiArgs';
 import login from './site/reducers/login';
 import siteConfig from './site/reducers/siteConfig';
@@ -47,6 +51,7 @@ const reducer = combineReducers({
   addonReview,
   addonReviewDetail,
   addonSubmit,
+  addonSubmitVersion,
   apiArgs,
   login,
   router,


### PR DESCRIPTION
- Add-on version submission is done through Dashboard Detail pages (dashboard -> add-on detail)
- Re-used what I could from add-on submission for add-on version submission without complicating things.
    - I was able to refactor out AddonUpload to its own component, but I had to copy/paste/adapt the actions code.
    - I was able to make the submit reducers generate a reducer so we could reuse the reducer for both add-on + add-on version.

![Sherlocked Capture](http://sherlocked.dev.mozaws.net/api/captures/8e4c0f8a815d469ca1c26c401f995bdf)