### PR TITLE
progress bar for add-on uploads

### DIFF
--- a/src/media/css/handlers/submissionAddon.styl
+++ b/src/media/css/handlers/submissionAddon.styl
@@ -1,6 +1,0 @@
-@import '../lib';
-
-
-.submission-addon form
-  display flex
-  align-items center

--- a/src/media/css/progressBar.styl
+++ b/src/media/css/progressBar.styl
@@ -1,0 +1,18 @@
+@import 'lib';
+
+
+.progress-bar
+  display flex
+  flex-direction column
+
+.progress-bar-bar
+  border 1px solid $color--grey
+  border-radius 20px
+  display block
+  height 40px
+  overflow hidden
+  width 320px
+
+.progress-bar-fill
+  background linear-gradient(to right, $color--blue, $color--blue-light)
+  height 100%

--- a/src/media/js/addon/actions/submit.js
+++ b/src/media/js/addon/actions/submit.js
@@ -13,24 +13,27 @@ import Url from 'urlgray';
 import urlJoin from 'url-join';
 
 
-export const VALIDATION_BEGIN = 'SUBMISSION_ADDON__VALIDATION_BEGIN';
+export const VALIDATION_BEGIN = 'ADDON_SUBMIT__VALIDATION_BEGIN';
 const validationBegin = createAction(VALIDATION_BEGIN);
 
+export const UPLOAD_PROGRESS = 'ADDON_SUBMIT__UPLOAD_PROGRESS';
+const uploadProgress = createAction(UPLOAD_PROGRESS);
+
 // For when the add-on upload has started processing.
-export const VALIDATION_PENDING = 'SUBMISSION_ADDON__VALIDATION_PENDING';
+export const VALIDATION_PENDING = 'ADDON_SUBMIT__VALIDATION_PENDING';
 const validationPending = createAction(VALIDATION_PENDING);
 
 // For when the add-on upload has finished validation.
-export const VALIDATION_PASS = 'SUBMISSION_ADDON__VALIDATION_PASS';
+export const VALIDATION_PASS = 'ADDON_SUBMIT__VALIDATION_PASS';
 const validationPassed = createAction(VALIDATION_PASS);
 
-export const VALIDATION_FAIL = 'SUBMISSION_ADDON__VALIDATION_FAIL';
+export const VALIDATION_FAIL = 'ADDON_SUBMIT__VALIDATION_FAIL';
 const validationFail = createAction(VALIDATION_FAIL);
 
-export const SUBMIT_OK = 'SUBMISSION_ADDON__SUBMIT_OK';
+export const SUBMIT_OK = 'ADDON_SUBMIT__SUBMIT_OK';
 const submitOk = createAction(SUBMIT_OK);
 
-export const SUBMIT_ERROR = 'SUBMISSION_ADDON__SUBMIT_ERROR';
+export const SUBMIT_ERROR = 'ADDON_SUBMIT__SUBMIT_ERROR';
 const submitError = createAction(SUBMIT_ERROR);
 
 
@@ -52,6 +55,14 @@ export function submit(fileData) {
       .set('Content-Disposition',
            'form-data; name="binary_data"; filename="extension.zip"')
       .send(fileData)
+      .on('progress', e => {
+        // Keep track of upload progress.
+        dispatch(uploadProgress({
+          // e.percent is also available, but we can math.
+          uploadLoaded: e.loaded,
+          uploadTotal: e.total
+        }))
+      })
       .then(res => {
         // Notify the reducers.
         dispatch(validationPending(res.body.id));

--- a/src/media/js/addon/actions/submitVersion.js
+++ b/src/media/js/addon/actions/submitVersion.js
@@ -19,6 +19,9 @@ import urlJoin from 'url-join';
 export const VALIDATION_BEGIN = 'ADDON_SUBMIT_VERSION__VALIDATION_BEGIN';
 const validationBegin = createAction(VALIDATION_BEGIN);
 
+export const UPLOAD_PROGRESS = 'ADDON_SUBMIT_VERSION__UPLOAD_PROGRESS';
+const uploadProgress = createAction(UPLOAD_PROGRESS);
+
 // For when the add-on upload has started processing.
 export const VALIDATION_PENDING = 'ADDON_SUBMIT_VERSION__VALIDATION_PENDING';
 const validationPending = createAction(VALIDATION_PENDING);
@@ -58,6 +61,14 @@ export function submitVersion(fileData, addonSlug) {
       .set('Content-Disposition',
            'form-data; name="binary_data"; filename="extension.zip"')
       .send(fileData)
+      .on('progress', e => {
+        // Keep track of upload progress.
+        dispatch(uploadProgress({
+          // e.percent is also available, but we can math.
+          uploadLoaded: e.loaded,
+          uploadTotal: e.total
+        }))
+      })
       .then(res => {
         // Notify the reducers.
         dispatch(validationPending(res.body.id));

--- a/src/media/js/addon/components/progressBar.js
+++ b/src/media/js/addon/components/progressBar.js
@@ -1,0 +1,48 @@
+/*
+  ProgressBar, primarily for file uploads.
+*/
+import React from 'react';
+
+
+function toFixedDown(number, digits) {
+  const re = new RegExp("(\\d+\\.\\d{" + digits + "})(\\d)");
+  const m = number.toString().match(re);
+  return m ? parseFloat(m[1]) : number.valueOf();
+}
+
+
+export default class ProgressBar extends React.Component {
+  static propTypes = {
+    loadedSize: React.PropTypes.number,
+    totalSize: React.PropTypes.number,
+    unit: React.PropTypes.string,
+  };
+
+  static defaultProps = {
+    loadedSize: 0,
+    totalSize: 100,
+    unit: '%',
+  };
+
+  render() {
+    const barFillStyle = {
+      width: `${this.props.loadedSize / this.props.totalSize * 100}%`
+    };
+
+    const loadedSize = toFixedDown(this.props.loadedSize, 2);
+    const totalSize = toFixedDown(this.props.totalSize, 2);
+
+    return (
+      <div className="progress-bar">
+        <div className="progress-bar-bar">
+          <div className="progress-bar-fill" style={barFillStyle}/>
+        </div>
+
+        <span className="progress-bar-text">
+          {loadedSize}{this.props.unit} /
+          {totalSize}{this.props.unit}
+        </span>
+      </div>
+    );
+  }
+}

--- a/src/media/js/addon/containers/dashboardDetail.js
+++ b/src/media/js/addon/containers/dashboardDetail.js
@@ -24,8 +24,12 @@ export class AddonDashboardDetail extends React.Component {
     fetchAddon: React.PropTypes.func.isRequired,
     fetchThreads: React.PropTypes.func.isRequired,
     fetchVersions: React.PropTypes.func.isRequired,
+    isSubmitting: React.PropTypes.bool,
     slug: React.PropTypes.string.isRequired,
-    submitVersion: React.PropTypes.func.isRequired,
+    submit: React.PropTypes.func.isRequired,
+    uploadLoaded: React.PropTypes.number,
+    uploadTotal: React.PropTypes.number,
+    validationErrorMessage: React.PropTypes.string,
   };
 
   constructor(props) {
@@ -53,9 +57,7 @@ export class AddonDashboardDetail extends React.Component {
         <Addon {...this.props.addon}/>
 
         <h3>Upload a New Version</h3>
-        <AddonUpload {...this.props.addonSubmitVersion}
-                     slug={this.props.slug}
-                     submit={this.props.submitVersion}/>
+        <AddonUpload {...this.props}/>
       </section>
     );
   }
@@ -72,6 +74,6 @@ export default connect(
     fetchAddon,
     fetchThreads,
     fetchVersions,
-    submitVersion
+    submit: submitVersion
   }, dispatch)
 )(AddonDashboardDetail);

--- a/src/media/js/addon/containers/submit.js
+++ b/src/media/js/addon/containers/submit.js
@@ -17,7 +17,9 @@ export class AddonSubmit extends React.Component {
   static propTypes = {
     isSubmitting: React.PropTypes.bool,
     submit: React.PropTypes.func.isRequired,
-    validationErrorMessage: React.PropTypes.string
+    uploadLoaded: React.PropTypes.number,
+    uploadTotal: React.PropTypes.number,
+    validationErrorMessage: React.PropTypes.string,
   };
 
   componentWillReceiveProps(nextProps) {
@@ -47,10 +49,7 @@ export class AddonSubmit extends React.Component {
 
 
 export default connect(
-  state => ({
-    isSubmitting: !!state.addonSubmit.isSubmitting,
-    validationErrorMessage: state.addonSubmit.validationErrorMessage,
-  }),
+  state => ({...state.addonSubmit}),
   dispatch => bindActionCreators({
     submit
   }, dispatch)

--- a/src/media/js/addon/reducers/submit.js
+++ b/src/media/js/addon/reducers/submit.js
@@ -12,6 +12,8 @@ import * as submitVersionActions from '../actions/submitVersion';
 
 const initialState = {
   isSubmitting: false,
+  uploadLoaded: null,
+  uploadTotal: null,
   validationErrorMessage: '',
   validationId: '',
 };
@@ -27,6 +29,17 @@ function createAddonSubmitReducer(actions) {
         return Object.assign({}, initialState, {
           isSubmitting: true
         });
+      }
+
+      case actions.UPLOAD_PROGRESS: {
+        /*
+          Add-on upload progress.
+
+          payload (object) --
+            uploadLoaded (number) -- bytes loaded.
+            uploadTotal (number) -- total bytes to load.
+        */
+        return Object.assign({}, state, action.payload);
       }
 
       case actions.VALIDATION_PENDING: {


### PR DESCRIPTION
- Uses ```superagent's .on('progress`)```
- Fixes file size display, was incorrectly representing bytes as KB

<img width="433" alt="screen shot 2015-09-11 at 4 25 22 pm" src="https://cloud.githubusercontent.com/assets/674727/9828419/f3b0ded2-58a1-11e5-9538-b684293c4e35.png">
<img width="560" alt="screen shot 2015-09-11 at 4 19 45 pm" src="https://cloud.githubusercontent.com/assets/674727/9828420/f3ce8c8e-58a1-11e5-8baf-85114e8180a9.png">
