### PR TITLE
Clean up addon status panel in the dashboard detail page.

### DIFF
--- a/src/media/css/containers/addon-dashboard-detail.styl
+++ b/src/media/css/containers/addon-dashboard-detail.styl
@@ -7,6 +7,9 @@
   max-width $layout--page-medium
 
 
+.addon-dashboard-detail h1
+  margin-bottom $layout--island-padding
+
 .addon-dashboard-detail--versions .page-section--main
   padding 0
 
@@ -52,3 +55,43 @@
 
     &:last-child
       border 0
+
+
+.addon-dashboard-detail--status
+  .addon-dashboard-detail--addon-status
+    color $color--grey-dark
+    font-size 14px
+    font-weight 300
+
+    p
+      margin 0
+
+    p:first-child
+      color $color--black
+      font-size 16px
+      font-weight 400
+
+  ul
+    border-top 1px solid $color--border
+    font-size 14px
+    margin 15px 0 0
+    padding 15px 0 0
+
+  li
+    margin-top 5px
+
+    &:first-child
+      margin 0
+
+  .addon--status-obsolete
+    color $color--status-netural
+
+  .addon--status-incomplete
+  .addon--status-rejected
+    color $color--status-problem
+
+  .addon--status-pending
+    color $color--status-waiting
+
+  .addon--status-public
+    color $color--status-public

--- a/src/media/js/addon/components/addon.js
+++ b/src/media/js/addon/components/addon.js
@@ -233,12 +233,70 @@ export class AddonForDashboard extends Addon {
 
 
 export class AddonForDashboardDetail extends Addon {
+  renderAddonStatus() {
+    return (
+      <div className="addon-dashboard-detail--addon-status">
+        {this.props.status === constants.STATUS_PUBLIC &&
+          <p>
+            Your add-on
+            is <span className="version--status-public">published</span>.
+          </p>
+        }
+        {this.props.status === constants.STATUS_PENDING &&
+          <div>
+            <p>
+              Your add-on is currently <span className="version--status-pending">
+              pending approval</span>.
+            </p>
+            <p>
+              You will receive an email when it has been reviewed.
+            </p>
+          </div>
+        }
+        {this.props.status === constants.STATUS_INCOMPLETE &&
+          <div>
+            <p>
+              Your add-on has been <span className="version--status-incomplete">
+              rejected</span>.
+            </p>
+            <p>
+              You will receive an email with further instructions.
+            </p>
+          </div>
+        }
+      </div>
+    );
+  }
+
+  renderVersionStatuses() {
+    return (
+      <ul>
+        {this.props.latest_version.status === constants.STATUS_PENDING &&
+          <li>
+            Version {this.props.latest_version.version} of your add-on
+            is <span className="version--status-pending">pending approval</span>.
+          </li>
+        }
+        {this.props.latest_version.status === constants.STATUS_REJECTED &&
+          <li>
+            Version {this.props.latest_version.version} of your add-on
+            has been <span className="version--status-rejected">rejected</span>.
+          </li>
+        }        <li>
+          Version {this.props.latest_public_version.version} of your add-on
+          is <span className="version--status-public">public</span>.
+        </li>
+      </ul>
+    );
+  }
+
   render() {
     return (
-      <PageSection>
-        <ReverseLink to={this.props.linkTo} params={{slug: this.props.slug}}>
-          {this.props.name}
-        </ReverseLink>
+      <PageSection className="addon-dashboard-detail--status">
+        {this.renderAddonStatus()}
+        {this.props.status === constants.STATUS_PUBLIC &&
+          this.renderVersionStatuses()
+        }
       </PageSection>
     );
   }

--- a/src/media/js/addon/containers/dashboardDetail.js
+++ b/src/media/js/addon/containers/dashboardDetail.js
@@ -71,7 +71,10 @@ export class AddonDashboardDetail extends React.Component {
 
         {!this.props.addon.deleted &&
           <div>
-            <AddonForDashboardDetail {...this.props.addon}/>
+            <AddonForDashboardDetail
+              className="addon-dashboard-detail--versions"
+              showDeveloperActions={true}
+              {...this.props.addon}/>
 
             <Provider store={this.context.store}>
               {() => <AddonVersionListingContainer


### PR DESCRIPTION
r? @ngokevin 

# If the addon status is `pending`

<img width="848" alt="screen shot 2015-10-01 at 5 13 51 pm" src="https://cloud.githubusercontent.com/assets/23885/10236180/0528dd4a-6860-11e5-9096-9f76d5686a11.png">

# If the addon status is `incomplete`

<img width="855" alt="screen shot 2015-10-01 at 5 13 58 pm" src="https://cloud.githubusercontent.com/assets/23885/10236185/0cd50d20-6860-11e5-8659-1a1f6b7c6df9.png">

# If the addon status is `public` and the latest version's status is also `public`

<img width="871" alt="screen shot 2015-10-01 at 5 16 09 pm" src="https://cloud.githubusercontent.com/assets/23885/10236198/2c25e78a-6860-11e5-8c1c-1b8e69fbada7.png">

# If the addon status is `public` and the latest version's status is `pending`

<img width="879" alt="screen shot 2015-10-01 at 5 14 22 pm" src="https://cloud.githubusercontent.com/assets/23885/10236203/393c1eda-6860-11e5-8783-b501686768d7.png">

# If the addon status is `public` and the latest version's status is `rejected`

<img width="877" alt="screen shot 2015-10-01 at 5 14 04 pm" src="https://cloud.githubusercontent.com/assets/23885/10236206/3eedc342-6860-11e5-81d6-0091d3be70d1.png">
