### PR TITLE
Adds messaging for rejected status.

### DIFF
--- a/src/media/js/addon/components/addon.js
+++ b/src/media/js/addon/components/addon.js
@@ -232,7 +232,8 @@ export class AddonForDashboardDetail extends Addon {
         {this.props.status === constants.STATUS_PUBLIC &&
           <p>
             Your add-on
-            is <span className="version--status-public">published</span>.
+            is <span className="version--status-public">published</span> and is
+            currently available on Marketplace.
           </p>
         }
         {this.props.status === constants.STATUS_PENDING &&
@@ -242,18 +243,32 @@ export class AddonForDashboardDetail extends Addon {
               pending approval</span>.
             </p>
             <p>
-              You will receive an email when it has been reviewed.
+              It is not currently available in Marketplace. You will receive an
+              email when it has been reviewed.
             </p>
           </div>
         }
         {this.props.status === constants.STATUS_INCOMPLETE &&
           <div>
             <p>
+              Your add-on is currently
+              <span className="version--status-incomplete"> incomplete</span>.
+            </p>
+            <p>
+              This means that there are no public versions. It is not currently
+              available in Marketplace. Please submit a new version for review.
+            </p>
+          </div>
+        }
+        {this.props.status === constants.STATUS_REJECTED &&
+          <div>
+            <p>
               Your add-on has been <span className="version--status-incomplete">
               rejected</span>.
             </p>
             <p>
-              You will receive an email with further instructions.
+              It is not currently available in Marketplace. You have been sent
+              an email with further instructions.
             </p>
           </div>
         }


### PR DESCRIPTION
r? @ngokevin @eviljeff 

These are now the current possible configurations of this section:

# Addon is incomplete

<img width="819" alt="addon-incomplete" src="https://cloud.githubusercontent.com/assets/23885/10287181/de4761c8-6b4e-11e5-85c8-4cbd330764de.png">

# Addon is pending approval

<img width="814" alt="addon-pending" src="https://cloud.githubusercontent.com/assets/23885/10287184/e3bc544c-6b4e-11e5-9a8e-cfb8ac3ec590.png">

# Addon has been rejected

<img width="809" alt="addon-rejected" src="https://cloud.githubusercontent.com/assets/23885/10287190/e9afd932-6b4e-11e5-968d-3310125c8762.png">

# Addon is public; latest version is public

<img width="813" alt="addon-published--version-public" src="https://cloud.githubusercontent.com/assets/23885/10287198/f716b67c-6b4e-11e5-80ca-244537b216b8.png">

# Addon is public; latest version is pending approval

<img width="808" alt="addon-published--version-pending" src="https://cloud.githubusercontent.com/assets/23885/10287231/25456dae-6b4f-11e5-9758-e78baef98eeb.png">

# Addon is public; latest version has been rejected

<img width="810" alt="addon-published-version-rejected" src="https://cloud.githubusercontent.com/assets/23885/10287209/075dc11a-6b4f-11e5-8735-a890fb8b5cb0.png">
