### PR TITLE
dashboard pagination

### DIFF
--- a/src/media/css/buttons.styl
+++ b/src/media/css/buttons.styl
@@ -28,6 +28,7 @@ a.button
   &[disabled]:hover
     background $color--disabled
     cursor default
+    pointer-events none
 
   &.button--success
     background $color--success

--- a/src/media/css/components/addon.styl
+++ b/src/media/css/components/addon.styl
@@ -1,15 +1,7 @@
 @import '../lib'
 
 
-.addon-dashboard .page--main
-.addon-dashboard h1
-  max-width $layout--page-medium
-
-.addon-listing--dashboard
-  margin 0
-
-
-.addon--dashboard
+.addon-for-dashboard
   align-items flex-start
   border-bottom 1px solid $color--border
   display flex
@@ -38,7 +30,7 @@
     margin-top 3px
 
 
-.addon--dashboard--meta
+.addon-for-dashboard--meta
   width 70%
 
   di
@@ -66,14 +58,6 @@
     color $color--status-public
 
 
-.addon--dashboard--links
+.addon-for-dashboard--links
   text-align right
   width 25%
-
-
-.addon-dashboard--notice
-  border-bottom 1px solid $color--border
-  font-size 13px
-  margin 0 0 $layout--list-padding
-  padding 0 0 ($layout--list-padding / 2)
-  text-align right

--- a/src/media/css/containers/addon-dashboard.styl
+++ b/src/media/css/containers/addon-dashboard.styl
@@ -1,11 +1,24 @@
 @import '../lib'
 
 
+.addon-dashboard .page--main
+.addon-dashboard h1
+  max-width $layout--page-medium
+
+
 .addon-dashboard
   .page--main
     background $color--white
     border-radius 5px
     padding $layout--island-padding
+
+
+.addon-dashboard-header
+  border-bottom 1px solid $color--border
+  display flex
+  justify-content space-between
+  margin-bottom 25px
+
 
 .addon-dashboard--empty
   .page--main
@@ -23,3 +36,14 @@
   a
     display inline-block
     margin 0 10px
+
+
+.addon-dashboard--notice
+  font-size 13px
+  margin 0 0 $layout--list-padding
+  padding 0 0 ($layout--list-padding / 2)
+  text-align right
+
+
+.addon-listing--dashboard
+  margin 0

--- a/src/media/css/paginator.styl
+++ b/src/media/css/paginator.styl
@@ -1,0 +1,3 @@
+.paginator
+  a
+    margin-right 5px

--- a/src/media/js/addon/actions/dashboard.js
+++ b/src/media/js/addon/actions/dashboard.js
@@ -12,7 +12,7 @@ export const DELETE_OK = 'ADDON_DASHBOARD__DELETE_OK';
 const deleteOk = createAction(DELETE_OK);
 
 
-export function fetch() {
+export function fetch(page=1) {
   /*
     Fetch user's add-ons.
   */
@@ -20,7 +20,7 @@ export function fetch() {
     const apiArgs = getState().apiArgs || {};
     const dashboardUrl = Url(
       urlJoin(process.env.MKT_API_ROOT, 'extensions/extension/')
-    ).q(apiArgs);
+    ).q(apiArgs).q({page});
 
     if (process.env.NODE_ENV === 'test') {
       // Mock data.
@@ -36,7 +36,12 @@ export function fetch() {
     req
       .get(dashboardUrl)
       .then(res => {
-        dispatch(fetchOk(res.body.objects));
+        dispatch(fetchOk({
+          addons: res.body.objects,
+          hasPrevPage: !!res.body.meta.previous,
+          hasNextPage: !!res.body.meta.next,
+          page
+        }));
       });
   };
 }

--- a/src/media/js/addon/components/addon.js
+++ b/src/media/js/addon/components/addon.js
@@ -8,26 +8,6 @@ import * as constants from '../constants';
 import {PageSection} from '../../site/components/page';
 
 
-export class AddonListing extends React.Component {
-  static propTypes = {
-    addons: React.PropTypes.array.isRequired
-  };
-
-  render() {
-    return (
-      <ul className="addon-listing">
-        {this.props.addons.map(addon =>
-          <li>
-            <Addon {...this.props} {...addon}/>
-          </li>
-        )}
-        {this.props.addons.length === 0 && <p>No add-ons.</p>}
-      </ul>
-    );
-  }
-}
-
-
 export class Addon extends React.Component {
   static propTypes = {
     description: React.PropTypes.string,
@@ -76,7 +56,7 @@ export class Addon extends React.Component {
   }
 
   render() {
-    const marketplaceURL = this.getMarketplaceUrl();
+    const marketplaceUrl = this.getMarketplaceUrl();
     return (
       <div className="addon">
         <div>
@@ -140,29 +120,16 @@ export class Addon extends React.Component {
             </di>
           }
 
-          {marketplaceURL &&
+          {marketplaceUrl &&
             <di>
               <dt>View on Marketplace</dt>
               <dd>
-                <a href={marketplaceURL}>{marketplaceURL}</a>
+                <a href={marketplaceUrl}>{marketplaceUrl}</a>
               </dd>
             </di>
           }
         </dl>
       </div>
-    );
-  }
-}
-
-
-export class AddonListingForDashboard extends AddonListing {
-  render() {
-    return (
-      <ul className="addon-listing--dashboard">
-        {this.props.addons.map(addon =>
-          <AddonForDashboard {...this.props} {...addon}/>
-        )}
-      </ul>
     );
   }
 }
@@ -183,15 +150,15 @@ export class AddonForDashboard extends Addon {
   }
 
   render() {
-    const marketplaceURL = this.getMarketplaceUrl();
+    const marketplaceUrl = this.getMarketplaceUrl();
     return (
-      <li className="addon--dashboard">
+      <li className="addon-for-dashboard">
         <h2>
           <ReverseLink to={this.props.linkTo} params={{slug: this.props.slug}}>
             {this.props.name}
           </ReverseLink>
         </h2>
-        <dl className="addon--dashboard--meta">
+        <dl className="addon-for-dashboard--meta">
           <di className={`addon--status-${this.props.status}`}>
             <dt>Status</dt>
             <dd>
@@ -201,7 +168,7 @@ export class AddonForDashboard extends Addon {
           </di>
           {this.renderLastUpdated()}
         </dl>
-        <nav className="addon--dashboard--links">
+        <nav className="addon-for-dashboard--links">
           <ul>
             <li>
               <ReverseLink to={this.props.linkTo}
@@ -209,9 +176,9 @@ export class AddonForDashboard extends Addon {
                 Edit this Add-on &raquo;
               </ReverseLink>
             </li>
-            {marketplaceURL &&
+            {marketplaceUrl &&
               <li>
-                <a href={marketplaceURL} target="_blank">
+                <a href={marketplaceUrl} target="_blank">
                   View on Marketplace &raquo;
                 </a>
               </li>
@@ -222,7 +189,6 @@ export class AddonForDashboard extends Addon {
     );
   }
 }
-
 
 
 export class AddonForDashboardDetail extends Addon {

--- a/src/media/js/addon/components/addonListing.js
+++ b/src/media/js/addon/components/addonListing.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import {Addon, AddonForDashboard} from './addon';
+
+
+export class AddonListing extends React.Component {
+  static propTypes = {
+    addons: React.PropTypes.array.isRequired
+  };
+
+  render() {
+    return (
+      <ul className="addon-listing">
+        {this.props.addons.map(addon =>
+          <li>
+            <Addon {...this.props} {...addon}/>
+          </li>
+        )}
+        {this.props.addons.length === 0 && <p>No add-ons.</p>}
+      </ul>
+    );
+  }
+}
+
+
+export class AddonListingForDashboard extends AddonListing {
+  render() {
+    return (
+      <ul className="addon-listing--dashboard">
+        {this.props.addons.map(addon =>
+          <AddonForDashboard {...this.props} {...addon}/>
+        )}
+      </ul>
+    );
+  }
+}

--- a/src/media/js/addon/containers/dashboard.js
+++ b/src/media/js/addon/containers/dashboard.js
@@ -5,16 +5,20 @@ import {bindActionCreators} from 'redux';
 import urlJoin from 'url-join';
 
 import {fetch} from '../actions/dashboard';
-import {AddonListingForDashboard} from '../components/addon';
+import {AddonListingForDashboard} from '../components/addonListing';
 import AddonSubnav from '../components/addonSubnav';
 import {addonListSelector} from '../selectors/addon';
 import {Page} from '../../site/components/page';
+import Paginator from '../../site/components/paginator';
 
 
 export class AddonDashboard extends React.Component {
   static PropTypes = {
     addons: React.PropTypes.array,
     fetch: React.PropTypes.func,
+    hasNextPage: React.PropTypes.bool,
+    hasPrevPage: React.PropTypes.bool,
+    page: React.PropTypes.number
   };
 
   static defaultProps = {
@@ -24,7 +28,7 @@ export class AddonDashboard extends React.Component {
 
   constructor(props) {
     super(props);
-    this.props.fetch();
+    this.props.fetch(this.props.page);
   }
 
   renderEmpty() {
@@ -49,10 +53,18 @@ export class AddonDashboard extends React.Component {
     return (
       <Page title="My Firefox OS Add-ons" subnav={<AddonSubnav/>}
             className="addon-dashboard">
-        <p className="addon-dashboard--notice">
-          Looking for your <a href={devhubLink} target="_blank">
-          webapp submissions</a>?
-        </p>
+
+        <div className="addon-dashboard-header">
+          <p className="addon-dashboard--notice">
+            Looking for your <a href={devhubLink} target="_blank">
+            webapp submissions</a>?
+          </p>
+          <Paginator hasNextPage={this.props.hasNextPage}
+                     hasPrevPage={this.props.hasPrevPage}
+                     page={this.props.page}
+                     to="addon-dashboard-page"/>
+        </div>
+
         <AddonListingForDashboard addons={this.props.addons}
                       linkTo="addon-dashboard-detail"/>
       </Page>
@@ -67,9 +79,17 @@ export class AddonDashboard extends React.Component {
 
 
 export default connect(
-  state => ({
-    addons: addonListSelector(state.addonDashboard.addons, true)
-  }),
+  state => {
+    const pageNum = parseInt(state.router.params.page, 10) || 1;
+    const page = state.addonDashboard.pages[pageNum] ||
+                 state.addonDashboard.pages[1];
+    return {
+      addons: page.addons,
+      hasNextPage: page.hasNextPage,
+      hasPrevPage: page.hasPrevPage,
+      page: pageNum
+    };
+  },
   dispatch => bindActionCreators({
     fetch
   }, dispatch)

--- a/src/media/js/addon/containers/review.js
+++ b/src/media/js/addon/containers/review.js
@@ -4,7 +4,7 @@ import {ReverseLink} from 'react-router-reverse';
 import {bindActionCreators} from 'redux';
 
 import {fetch} from '../actions/review';
-import {AddonListing} from '../components/addon';
+import {AddonListing} from '../components/addonListing';
 import AddonSubnav from '../components/addonSubnav';
 import {addonListSelector} from '../selectors/addon';
 import {Page} from '../../site/components/page';

--- a/src/media/js/addon/reducers/addon.js
+++ b/src/media/js/addon/reducers/addon.js
@@ -100,11 +100,12 @@ export default function addonReducer(state=initialState, action) {
       /*
         Get add-ons from dashboard.
 
-        payload (array) -- add-ons.
+        payload (object) --
+          addons (array) -- add-ons.
       */
       const newState = _.cloneDeep(state);
 
-      action.payload.forEach(addon => {
+      action.payload.addons.forEach(addon => {
         newState.addons[addon.slug] = Object.assign(
           {}, newState.addons[addon.slug] || {}, addon
         );

--- a/src/media/js/addon/reducers/dashboard.js
+++ b/src/media/js/addon/reducers/dashboard.js
@@ -1,5 +1,5 @@
 /*
-  Add-ons in the user dashboard, keyed by slug.
+  Add-ons in the user dashboard, paginated, and keyed by slug.
 */
 import _ from 'lodash';
 
@@ -9,46 +9,34 @@ import * as submitActions from '../actions/submit';
 
 const initialState = {
   __persist: true,
-  addons: {}
+  pages: {
+    1: {
+      addons: [],
+      hasNextPage: false,
+    }
+  }
 };
 
 
 export default function addonDashboardReducer(state=initialState, action) {
   switch (action.type) {
-    case dashboardActions.DELETE_OK: {
-      /*
-        Remove deleted add-on from listing.
-
-        payload (string) -- addonSlug
-      */
-      const newState = _.cloneDeep(state);
-      delete newState.addons[action.payload]
-      return newState;
-    }
-
     case dashboardActions.FETCH_OK: {
       /*
         Set dashboards add-ons.
 
-        payload (array) -- add-ons.
+        payload (object) --
+          addons - list of add-ons.
+          hasNextPage - whether there's a next page.
+          page - page number.
       */
       const newState = _.cloneDeep(state);
-      newState.addons = {};  // Invalidate.
-      // Set new add-ons.
-      action.payload.forEach(addon => {
-        newState.addons[addon.slug] = addon;
-      });
-      return newState;
-    }
 
-    case submitActions.SUBMIT_OK: {
-      /*
-        Add add-on to dashboard after submit.
+      newState.pages[action.payload.page] = {
+        addons: action.payload.addons,
+        hasNextPage: action.payload.hasNextPage,
+        hasPrevPage: action.payload.hasPrevPage
+      };
 
-        payload (object) -- add-on.
-      */
-      const newState = _.cloneDeep(state);
-      newState.addons[action.payload.slug] = action.payload;
       return newState;
     }
 

--- a/src/media/js/app.js
+++ b/src/media/js/app.js
@@ -109,7 +109,10 @@ function renderRoutes() {
             <Route name="addon" path="/addon">
               <Route name="addon-dashboard" path="/dashboard/"
                      component={loginRequired(AddonDashboard, Login,
-                                             ADDON_SUBMIT)}/>
+                                              ADDON_SUBMIT)}/>
+              <Route name="addon-dashboard-page" path="/dashboard/page/:page"
+                     component={loginRequired(AddonDashboard, Login,
+                                              ADDON_SUBMIT)}/>
               <Route name="addon-dashboard-detail" path="/dashboard/:slug"
                      component={loginRequired(AddonDashboardDetail, Login,
                                               ADDON_SUBMIT)}/>

--- a/src/media/js/site/components/page.js
+++ b/src/media/js/site/components/page.js
@@ -39,7 +39,7 @@ export class PageHeader extends React.Component {
     const showBreadcrumb = (this.props.breadcrumbText &&
                             this.props.breadcrumbTo);
     return (
-      <header className="page--header">
+      <div className="page--header">
         {this.props.subnav}
         {showBreadcrumb &&
           <div className="page--breadcrumb">
@@ -49,7 +49,7 @@ export class PageHeader extends React.Component {
           </div>
         }
         <h1>{this.props.title}</h1>
-      </header>
+      </div>
     );
   }
 }

--- a/src/media/js/site/components/paginator.js
+++ b/src/media/js/site/components/paginator.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import {ReverseLink} from 'react-router-reverse';
+
+
+export default class Paginator extends React.Component {
+  static propTypes = {
+    hasNextPage: React.PropTypes.bool,
+    hasPrevPage: React.PropTypes.bool,
+    page: React.PropTypes.number,
+    to: React.PropTypes.string,
+  };
+
+  render() {
+    return (
+      <div className="paginator">
+        <ReverseLink className="paginator-prev button"
+                     disabled={!this.props.hasPrevPage}
+                     params={{page: this.props.page - 1}} to={this.props.to}>
+          Prev Page
+        </ReverseLink>
+        <ReverseLink className="paginator-next button"
+                     disabled={!this.props.hasNextPage}
+                     params={{page: this.props.page + 1}} to={this.props.to}>
+          Next Page
+        </ReverseLink>
+      </div>
+    );
+  }
+}

--- a/src/media/js/site/components/subnav.js
+++ b/src/media/js/site/components/subnav.js
@@ -1,7 +1,4 @@
-import classnames from 'classnames';
-import {connect} from 'react-redux';
 import React from 'react';
-import {reverse, ReverseLink} from 'react-router-reverse';
 
 
 export class Subnav extends React.Component {


### PR DESCRIPTION
- store add-ons in the dashboard reducer by page
- if the user goes to an invalid page that doesn't have add-ons, just display the first page
- separate addon and addon listing components to separate files
- clear the minefield by ```s/addon--dashboard/addon-for-dashboard```. how we use double-dashes in class names is not really consistent nor agreed upon. i think double dashes should be preserved for modifiers (e.g., ```link--active``` or ```version--collapsed```)