### PR TITLE
notification queue

### DIFF
--- a/src/media/css/components/notification.styl
+++ b/src/media/css/components/notification.styl
@@ -1,0 +1,21 @@
+@import '../lib';
+
+
+.notification
+  background $color--black
+  border-top 1px solid $color--grey
+  bottom 0
+  color $color--white
+  font-size 20px
+  display flex
+  padding 30px 0
+  position fixed
+  transition transform .4s
+  transform translateY(100px)
+  justify-content center
+  width 100%
+
+  &[data-notification--is-visible="true"] {
+    transform translateY(0)
+    transition transform .4s
+  }

--- a/src/media/css/components/progressBar.styl
+++ b/src/media/css/components/progressBar.styl
@@ -1,4 +1,4 @@
-@import 'lib';
+@import '../lib';
 
 
 .progress-bar

--- a/src/media/js/addon/actions/submit.js
+++ b/src/media/js/addon/actions/submit.js
@@ -12,6 +12,8 @@ import req from 'request';
 import Url from 'urlgray';
 import urlJoin from 'url-join';
 
+import * as notificationActions from '../../site/actions/notification';
+
 
 export const VALIDATION_BEGIN = 'ADDON_SUBMIT__VALIDATION_BEGIN';
 const validationBegin = createAction(VALIDATION_BEGIN);
@@ -74,6 +76,7 @@ export function submit(fileData) {
         dispatch(pollValidator(res.body.id));
       }, err => {
         dispatch(validationFail(JSON.parse(err.response.text).detail));
+        _validationErrorNotification(dispatch);
       });
   };
 }
@@ -136,8 +139,18 @@ export function create() {
       })
       .then(res => {
         dispatch(submitOk(res.body));
+        dispatch(notificationActions.queue(
+          'Your Firefox OS Add-on has been successfully submitted!',
+          'success'));
       }, err => {
         dispatch(validationFail(JSON.parse(err.response.text).detail));
+        _validationErrorNotification(dispatch);
       });
   };
+}
+
+
+function _validationErrorNotification(dispatch) {
+  dispatch(notificationActions.queue(
+    'Sorry, we found an error with your Firefox OS Add-on.', 'error'));
 }

--- a/src/media/js/addon/actions/submitVersion.js
+++ b/src/media/js/addon/actions/submitVersion.js
@@ -17,6 +17,7 @@ import urlJoin from 'url-join';
 
 import {fetchThreads} from './comm';
 import {fetchVersions} from './addon';
+import * as notificationActions from '../../site/actions/notification';
 
 
 export const VALIDATION_BEGIN = 'ADDON_SUBMIT_VERSION__VALIDATION_BEGIN';
@@ -83,6 +84,7 @@ export function submitVersion(fileData, addonSlug) {
         dispatch(pollValidator(res.body.id, addonSlug));
       }, err => {
         dispatch(validationFail(JSON.parse(err.response.text).detail));
+        _validationErrorNotification(dispatch);
       });
   };
 }
@@ -114,6 +116,7 @@ export function pollValidator(validationId, addonSlug) {
               dispatch(createVersion(addonSlug));
             } else {
               dispatch(validationFail(res.body.validation));
+              _validationErrorNotification(dispatch);
             }
           }
         });
@@ -149,6 +152,12 @@ export function createVersion(addonSlug) {
           addonSlug,
           version: res.body
         }));
+
+        // Success message.
+        dispatch(notificationActions.queue(
+          'Your Firefox OS Add-on version has been successfully submitted!',
+          'success'));
+
         // Fetch versions.
         dispatch(fetchVersions(addonSlug));
 
@@ -156,6 +165,13 @@ export function createVersion(addonSlug) {
         dispatch(fetchThreads(addonSlug));
       }, err => {
         dispatch(validationFail(JSON.parse(err.response.text).detail));
+        _validationErrorNotification(dispatch);
       });
   };
+}
+
+
+function _validationErrorNotification(dispatch) {
+  dispatch(notificationActions.queue(
+    'Sorry, we found an error with your Firefox OS Add-on version.', 'error'));
 }

--- a/src/media/js/app.js
+++ b/src/media/js/app.js
@@ -35,6 +35,7 @@ import {addonSubmitReducer as
         addonSubmitVersion} from './addon/reducers/submit';
 import apiArgs from './site/reducers/apiArgs';
 import login from './site/reducers/login';
+import notification from './site/reducers/notification';
 import siteConfig from './site/reducers/siteConfig';
 import user from './site/reducers/user';
 
@@ -49,6 +50,7 @@ const reducer = combineReducers({
   addonThread,
   apiArgs,
   login,
+  notification,
   router,
   siteConfig,
   user,

--- a/src/media/js/site/actions/notification.js
+++ b/src/media/js/site/actions/notification.js
@@ -1,0 +1,32 @@
+import {createAction} from 'redux-actions';
+
+
+export const NOTIFICATION_QUEUE = 'NOTIFICATION__QUEUE';
+export const notificationQueue = createAction(NOTIFICATION_QUEUE);
+
+export const NOTIFICATION_SHIFT = 'NOTIFICATION__SHIFT';
+export const notificationShift = createAction(NOTIFICATION_SHIFT);
+
+
+export function queue(message, className, duration=5000) {
+  return (dispatch, getState) => {
+    // Calculate how long this notification will wait in the queue
+    // before we queue it.
+    let totalDuration = 0;
+    getState().notification.notificationQueue.forEach(notification => {
+      totalDuration += notification.duration || 0;
+    });
+
+    // Queue.
+    dispatch(notificationQueue({
+      className,
+      duration,
+      message
+    }));
+
+    // Shift the notification when it comes time.
+    setTimeout(() => {
+      dispatch(notificationShift());
+    }, totalDuration + duration);
+  };
+}

--- a/src/media/js/site/components/notification.js
+++ b/src/media/js/site/components/notification.js
@@ -1,0 +1,39 @@
+import classnames from 'classnames';
+import React from 'react';
+
+
+export default class Notification extends React.Component {
+  static propTypes = {
+    notification: React.PropTypes.any
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVisible: !!this.props.notification
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({isVisible: !!nextProps.notification});
+  }
+
+  render() {
+    let notificationClasses = {
+      notification: true
+    };
+    if (this.props.notification && this.props.notification.className) {
+      notificationClasses[this.props.notificationClassName] = true;
+    }
+    notificationClasses = classnames(notificationClasses);
+
+    return (
+      <div className="notification"
+           data-notification--is-visible={this.state.isVisible}>
+        {this.props.notification && this.props.notification.message &&
+         this.props.notification.message
+        }
+      </div>
+    );
+  }
+}

--- a/src/media/js/site/containers/app.js
+++ b/src/media/js/site/containers/app.js
@@ -4,10 +4,9 @@ import {connect} from 'react-redux';
 
 import {fxaLoginBegin, login, loginOk, logout} from '../actions/login';
 import {fetch as siteConfigFetch} from '../actions/siteConfig';
-
 import Footer from '../components/footer';
+import Notification from '../components/notification';
 import Header from '../components/header';
-
 import {initialState as siteConfigInitialState} from '../reducers/siteConfig';
 import {initialState as userInitialState} from '../reducers/user';
 
@@ -19,6 +18,7 @@ export class App extends React.Component {
     login: React.PropTypes.func.isRequired,
     loginOk: React.PropTypes.func.isRequired,
     logout: React.PropTypes.func.isRequired,
+    notification: React.PropTypes.any,
     siteConfig: React.PropTypes.object.isRequired,
     siteConfigFetch: React.PropTypes.func.isRequired,
     user: React.PropTypes.object.isRequired,
@@ -64,6 +64,8 @@ export class App extends React.Component {
           {this.props.children}
         </main>
         <Footer/>
+
+        <Notification notification={this.props.notification}/>
       </div>
     );
   }
@@ -72,8 +74,8 @@ export class App extends React.Component {
 
 export default connect(
   state => ({
+    notification: state.notification.notification,
     siteConfig: state.siteConfig,
-    ui: state.ui,
     user: state.user,
   }),
   dispatch => bindActionCreators({

--- a/src/media/js/site/reducers/__tests__/notification.test.js
+++ b/src/media/js/site/reducers/__tests__/notification.test.js
@@ -1,0 +1,50 @@
+import notificationReducer from '../notification';
+import * as notificationActions from '../../actions/notification';
+
+
+describe('notificationReducer', () => {
+  it('sets notification on blank queue', () => {
+    const state = notificationReducer({
+      notificationQueue: [],
+      notification: null
+    }, {
+      type: notificationActions.NOTIFICATION_QUEUE,
+      payload: {message: 'success'}
+    });
+    assert.equal(state.notification.message, 'success');
+  });
+
+  it('queues notification', () => {
+    const state = notificationReducer({
+      notificationQueue: [],
+      notification: {message: 'success'}
+    }, {
+      type: notificationActions.NOTIFICATION_QUEUE,
+      payload: {message: 'sike u failed'}
+    });
+    assert.equal(state.notificationQueue[0].message, 'sike u failed');
+    assert.equal(state.notification.message, 'success');
+  });
+
+  it('shifts notification with empty queue', () => {
+    const state = notificationReducer({
+      notificationQueue: [],
+      notification: {message: 'success'}
+    }, {
+      type: notificationActions.NOTIFICATION_SHIFT,
+    });
+    assert.equal(state.notificationQueue.length, 0);
+    assert.equal(state.notification, null);
+  });
+
+  it('shifts notification with non-empty queue', () => {
+    const state = notificationReducer({
+      notificationQueue: [{message: 'sike u failed'}, {message: 'nvm pass'}],
+      notification: {message: 'success'}
+    }, {
+      type: notificationActions.NOTIFICATION_SHIFT,
+    });
+    assert.equal(state.notificationQueue.length, 1);
+    assert.equal(state.notification.message, 'sike u failed');
+  });
+});

--- a/src/media/js/site/reducers/notification.js
+++ b/src/media/js/site/reducers/notification.js
@@ -1,0 +1,54 @@
+import _ from 'lodash';
+
+import * as notificationActions from '../actions/notification';
+
+
+const initialState = {
+  notificationQueue: [],
+  notification: null
+};
+
+
+export default function notificationReducer(state=initialState, action) {
+  switch (action.type) {
+    case notificationActions.NOTIFICATION_SHIFT: {
+      /*
+        Invalidate current notification.
+        Bring next notification in from the queue if any.
+
+        No payload.
+      */
+      let newState = _.cloneDeep(state);
+      if (newState.notificationQueue.length) {
+        newState.notification = newState.notificationQueue.shift();
+      } else {
+        newState.notification = null;
+      }
+      return newState;
+    }
+
+    case notificationActions.NOTIFICATION_QUEUE: {
+      /*
+        Add notification to queue.
+        Set notification if none in queue waiting.
+
+        payload (object) -- notification.
+          id (number) -- ID of notification. Keep track to pop later.
+          className (string) -- class name to style notification.
+          duration (number) -- how long notification will appear.
+          message (string) -- notification message.
+      */
+      let newState = _.cloneDeep(state);
+      if (newState.notification) {
+        newState.notificationQueue.push(action.payload);
+      } else {
+        newState.notification = action.payload;
+      }
+      return newState;
+    }
+
+    default: {
+      return state;
+    }
+  }
+}


### PR DESCRIPTION
Basic gist:

![notification](https://cloud.githubusercontent.com/assets/674727/10321910/1ad03124-6c30-11e5-9340-e91fc568313c.gif)

- I updated the copy + duration since that screenshot.
- Not sure why the transition isn't triggering both ways. But not spending much time thinking about it.
- Added messages for submit/fail for addon/versions