### PR TITLE
getInstalled to keep installed apps up-to-date, fix tests (bug 1213820)

### DIFF
--- a/src/media/js/addon/actions/addon.js
+++ b/src/media/js/addon/actions/addon.js
@@ -11,15 +11,6 @@ const fetchOk = createAction(FETCH_OK);
 export const FETCH_VERSIONS_OK = 'ADDON_ADDON__FETCH_VERSIONS_OK';
 const fetchVersionsOk = createAction(FETCH_VERSIONS_OK);
 
-export const INSTALL_BEGIN = 'ADDON_INSTALL__INSTALL_BEGIN';
-const installBegin = createAction(INSTALL_BEGIN);
-
-export const INSTALL_ERROR = 'ADDON_INSTALL__INSTALL_ERROR';
-const installError = createAction(INSTALL_ERROR);
-
-export const INSTALL_OK = 'ADDON_INSTALL__INSTALL_OK';
-const installOk = createAction(INSTALL_OK);
-
 
 export function fetch(addonSlug) {
   /*
@@ -78,30 +69,5 @@ export function fetchVersions(addonSlug) {
           versions: res.body.objects
         }));
       });
-  };
-}
-
-
-export function install(addonSlug, manifestUrl) {
-  /*
-    Install add-on.
-  */
-  return (dispatch, getState) => {
-    const apiArgs = getState().apiArgs || {};
-    manifestUrl = Url(manifestUrl).q(apiArgs);
-
-    const req = window.navigator.mozApps.installPackage(manifestUrl);
-    dispatch(installBegin(addonSlug));
-
-    req.onsuccess = err => {
-      dispatch(installOk(addonSlug));
-    }
-
-    req.onerror = err => {
-      dispatch(installError({
-        addonSlug,
-        errorMessage: err.target.error.name
-      }));
-    }
   };
 }

--- a/src/media/js/addon/actions/mozApps.js
+++ b/src/media/js/addon/actions/mozApps.js
@@ -1,0 +1,65 @@
+'use strict';
+import {createAction} from 'redux-actions';
+import Url from 'urlgray';
+
+
+export const GET_INSTALLED_OK = 'MOZAPPS__GET_INSTALLED_OK';
+const getInstalledOk = createAction(GET_INSTALLED_OK);
+
+export const INSTALL_BEGIN = 'MOZAPPS__INSTALL_BEGIN';
+const installBegin = createAction(INSTALL_BEGIN);
+
+export const INSTALL_ERROR = 'MOZAPPS__INSTALL_ERROR';
+const installError = createAction(INSTALL_ERROR);
+
+export const INSTALL_OK = 'MOZAPPS__INSTALL_OK';
+const installOk = createAction(INSTALL_OK);
+
+
+export function getInstalled(addonSlug, manifestUrl) {
+  /*
+    Query for add-ons that are installed.
+  */
+  return dispatch => {
+    if (!('mozApps' in window.navigator)) {
+      return;
+    }
+
+    const req = window.navigator.mozApps.getInstalled();
+
+    req.onsuccess = () => {
+      dispatch(getInstalledOk(
+        req.result.map(result => result.manifestURL)
+      ));
+    };
+  };
+}
+
+
+export function install(addonSlug, manifestUrl) {
+  /*
+    Install add-on.
+  */
+  return (dispatch, getState) => {
+    if (!('mozApps' in window.navigator)) {
+      return;
+    }
+
+    const apiArgs = getState().apiArgs || {};
+    manifestUrl = Url(manifestUrl).q(apiArgs);
+
+    const req = window.navigator.mozApps.installPackage(manifestUrl);
+    dispatch(installBegin(addonSlug));
+
+    req.onsuccess = () => {
+      dispatch(installOk(addonSlug));
+    }
+
+    req.onerror = err => {
+      dispatch(installError({
+        addonSlug,
+        errorMessage: err.target.error.name
+      }));
+    }
+  };
+}

--- a/src/media/js/addon/components/subnav.js
+++ b/src/media/js/addon/components/subnav.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import {ADDON_REVIEW, ADDON_SUBMIT} from '../../app';
 import {Subnav} from '../../site/components/subnav';
 import {SubnavItem} from '../../site/components/subnavItem';
+import {ADDON_REVIEW, ADDON_SUBMIT} from '../../site/constants/login';
 
 
 export default class AddonSubnav extends React.Component {

--- a/src/media/js/addon/containers/__tests__/dashboard.test.js
+++ b/src/media/js/addon/containers/__tests__/dashboard.test.js
@@ -11,8 +11,7 @@ describe('AddonDashboard', () => {
 
   it('renders', () => {
     const component = ReactDOMHelper.render(
-      <StubRouterProvider Component={AddonDashboard}
-                          {...props}/>
+      <StubRouterProvider Component={AddonDashboard} {...props}/>
     );
     assert.equal(
       ReactDOMHelper.queryClassAll(component,

--- a/src/media/js/addon/containers/__tests__/reviewDetail.test.js
+++ b/src/media/js/addon/containers/__tests__/reviewDetail.test.js
@@ -9,6 +9,8 @@ describe('AddonReviewDetail', () => {
     fetchAddon: () => {},
     fetchThreads: () => {},
     fetchVersions: () => {},
+    getInstalledAddons: () => {},
+    installAddon: () => {},
     user: {},
   };
 

--- a/src/media/js/addon/containers/dashboard.js
+++ b/src/media/js/addon/containers/dashboard.js
@@ -6,7 +6,7 @@ import urlJoin from 'url-join';
 
 import {fetch} from '../actions/dashboard';
 import {AddonListingForDashboard} from '../components/addonListing';
-import AddonSubnav from '../components/addonSubnav';
+import AddonSubnav from '../components/subnav';
 import {addonListSelector} from '../selectors/addon';
 import {Page} from '../../site/components/page';
 import Paginator from '../../site/components/paginator';

--- a/src/media/js/addon/containers/dashboardDetail.js
+++ b/src/media/js/addon/containers/dashboardDetail.js
@@ -11,7 +11,7 @@ import {fetch as fetchAddon} from '../actions/addon';
 import {del as deleteAddon} from '../actions/dashboard';
 import {messageChange, submitVersion} from '../actions/submitVersion';
 import {Addon, AddonForDashboardDetail} from '../components/addon';
-import AddonSubnav from '../components/addonSubnav';
+import AddonSubnav from '../components/subnav';
 import AddonUpload from '../components/upload';
 import ConfirmButton from '../../site/components/confirmButton';
 import {Page, PageSection} from '../../site/components/page';

--- a/src/media/js/addon/containers/review.js
+++ b/src/media/js/addon/containers/review.js
@@ -5,7 +5,7 @@ import {bindActionCreators} from 'redux';
 
 import {fetch} from '../actions/review';
 import {AddonListing} from '../components/addonListing';
-import AddonSubnav from '../components/addonSubnav';
+import AddonSubnav from '../components/subnav';
 import {addonListSelector} from '../selectors/addon';
 import {Page} from '../../site/components/page';
 

--- a/src/media/js/addon/containers/reviewDetail.js
+++ b/src/media/js/addon/containers/reviewDetail.js
@@ -9,10 +9,12 @@ import {ReverseLink} from 'react-router-reverse';
 import {bindActionCreators} from 'redux';
 
 import AddonVersionListingContainer from './versionListing';
-import {fetch as fetchAddon, install as installAddon} from '../actions/addon';
+import {fetch as fetchAddon} from '../actions/addon';
+import {getInstalled as getInstalledAddons,
+        install as installAddon} from '../actions/mozApps';
 import {Addon} from '../components/addon';
 import AddonInstall from '../components/install';
-import AddonSubnav from '../components/addonSubnav';
+import AddonSubnav from '../components/subnav';
 import {Page} from '../../site/components/page';
 
 
@@ -23,6 +25,7 @@ export class AddonReviewDetail extends React.Component {
   static propTypes = {
     addon: React.PropTypes.object,
     fetchAddon: React.PropTypes.func.isRequired,
+    getInstalledAddons: React.PropTypes.func.isRequired,
     installAddon: React.PropTypes.func.isRequired,
     slug: React.PropTypes.string.isRequired,
     user: React.PropTypes.object,
@@ -31,6 +34,7 @@ export class AddonReviewDetail extends React.Component {
   constructor(props) {
     super(props);
     this.props.fetchAddon(this.props.slug);
+    this.props.getInstalledAddons();
   }
 
   render() {
@@ -47,13 +51,15 @@ export class AddonReviewDetail extends React.Component {
             subnav={<AddonSubnav user={this.props.user}/>}>
         <Addon {...addon} showWaitingTime={true}/>
 
-        <AddonInstall
-          install={this.props.installAddon}
-          installErrorMessage={addon.installErrorMessage}
-          isInstalled={addon.isInstalled}
-          isInstalling={addon.isInstalling}
-          manifestUrl={addon.latest_version.reviewer_mini_manifest_url}
-          slug={addon.slug}/>
+        {addon.latest_version &&
+          <AddonInstall
+            install={this.props.installAddon}
+            installErrorMessage={addon.installErrorMessage}
+            isInstalled={addon.isInstalled}
+            isInstalling={addon.isInstalling}
+            manifestUrl={addon.latest_version.reviewer_mini_manifest_url}
+            slug={addon.slug}/>
+        }
 
         <Provider store={this.context.store}>
           {() => <AddonVersionListingContainer showReviewActions={true}/>}
@@ -71,6 +77,7 @@ export default connect(
   }),
   dispatch => bindActionCreators({
     fetchAddon,
+    getInstalledAddons,
     installAddon,
   }, dispatch)
 )(AddonReviewDetail);

--- a/src/media/js/addon/containers/submit.js
+++ b/src/media/js/addon/containers/submit.js
@@ -4,7 +4,7 @@ import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 
 import {messageChange, submit} from '../actions/submit';
-import AddonSubnav from '../components/addonSubnav';
+import AddonSubnav from '../components/subnav';
 import AddonUpload from '../components/upload';
 import {Page} from '../../site/components/page';
 

--- a/src/media/js/addon/containers/versionListing.js
+++ b/src/media/js/addon/containers/versionListing.js
@@ -47,8 +47,12 @@ export class AddonVersionListing extends React.Component {
   }
 
   render() {
+    const pageStyle = {
+      display: this.props.versions.length ? 'block' : 'none'
+    };
     return (
-      <PageSection className={this.props.className} title="Versions">
+      <PageSection className={this.props.className} title="Versions"
+                   style={pageStyle}>
         <ul>{this.props.versions.map(this.renderVersion)}</ul>
       </PageSection>
     );

--- a/src/media/js/addon/reducers/__tests__/addon.test.js
+++ b/src/media/js/addon/reducers/__tests__/addon.test.js
@@ -1,6 +1,7 @@
 import addonReducer from '../addon';
 import * as addonActions from '../../actions/addon';
 import * as dashboardActions from '../../actions/dashboard';
+import * as mozAppsActions from '../../actions/mozApps';
 import * as reviewActions from '../../actions/review';
 import * as submitVersionActions from '../../actions/submitVersion';
 import * as constants from '../../constants';
@@ -154,5 +155,40 @@ describe('addonReducer', () => {
       }
     );
     assert.ok(newState.addons.slugly.deleted);
+  });
+
+  it('updates installed states of add-ons', () => {
+    const newState = addonReducer(
+      {
+        addons: {
+          wasInstalled: {
+            latest_version: {reviewer_mini_manifest_url: 'was.installed'},
+            isInstalled: true,
+          },
+          stillInstalled: {
+            latest_version: {reviewer_mini_manifest_url: 'still.installed'},
+            isInstalled: true
+          },
+          nowInstalled: {
+            latest_version: {reviewer_mini_manifest_url: 'now.installed'},
+            isInstalled: false
+          },
+          noLatestVersion: {},
+        },
+      },
+      {
+        type: mozAppsActions.GET_INSTALLED_OK,
+        payload: ['still.installed', 'now.installed']
+      }
+    );
+
+    assert.notOk(newState.addons.wasInstalled.isInstalled,
+                 'wasInstalled should no longer be installed');
+    assert.ok(newState.addons.stillInstalled.isInstalled,
+              'stillInstalled should still be installed');
+    assert.ok(newState.addons.nowInstalled.isInstalled,
+              'nowInstalled should now be installed');
+    assert.notOk(newState.addons.noLatestVersion.isInstalled,
+                 'apps fetched as a non-reviewer should not be installed');
   });
 });

--- a/src/media/js/addon/reducers/addon.js
+++ b/src/media/js/addon/reducers/addon.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 import * as addonActions from '../actions/addon';
 import * as dashboardActions from '../actions/dashboard';
+import * as mozAppsActions from '../actions/mozApps';
 import * as reviewActions from '../actions/review';
 import * as submitActions from '../actions/submit';
 import * as submitVersionActions from '../actions/submitVersion';
@@ -58,44 +59,6 @@ export default function addonReducer(state=initialState, action) {
       return newState;
     }
 
-    case addonActions.INSTALL_BEGIN: {
-      /*
-        Add-on installation begin.
-
-        payload (string) -- slug of add-on being installed.
-      */
-      const newState = _.cloneDeep(state);
-      newState.addons[action.payload].isInstalling = true;
-      return newState;
-    }
-
-    case addonActions.INSTALL_ERROR: {
-      /*
-        Add-on installation error.
-
-        payload (object) --
-          addonSlug (string) -- slug of add-on that failed to install.
-          errorMessage (string) -- error message from browser.
-      */
-      const newState = _.cloneDeep(state);
-      const {addonSlug, errorMessage} = action.payload;
-      newState.addons[addonSlug].installErrorMessage = errorMessage;
-      newState.addons[addonSlug].isInstalling = false;
-      return newState;
-    }
-
-    case addonActions.INSTALL_OK: {
-      /*
-        Add-on installation success.
-
-        payload (string) -- slug of add-on installed.
-      */
-      const newState = _.cloneDeep(state);
-      newState.addons[action.payload].isInstalling = false;
-      newState.addons[action.payload].isInstalled = true;
-      return newState;
-    }
-
     case dashboardActions.FETCH_OK: {
       /*
         Get add-ons from dashboard.
@@ -121,6 +84,71 @@ export default function addonReducer(state=initialState, action) {
       */
       const newState = _.cloneDeep(state);
       newState.addons[action.payload].deleted = true;
+      return newState;
+    }
+
+    case mozAppsActions.GET_INSTALLED_OK: {
+      /*
+        Queried for installed add-ons.
+
+        payload (array) - array of manifestURL strings.
+      */
+      const newState = _.cloneDeep(state);
+
+      Object.keys(newState.addons).forEach(slug => {
+        let addon = newState.addons[slug];
+
+        if (!addon.latest_version) {
+          addon.isInstalled = false;
+          return;
+        }
+
+        const manifestUrl = addon.latest_version.reviewer_mini_manifest_url;
+        if (!manifestUrl || action.payload.indexOf(manifestUrl) === -1) {
+          addon.isInstalled = false;
+          return;
+        }
+
+        addon.isInstalled = true;
+      });
+      return newState;
+    }
+
+    case mozAppsActions.INSTALL_BEGIN: {
+      /*
+        Add-on installation begin.
+
+        payload (string) -- slug of add-on being installed.
+      */
+      const newState = _.cloneDeep(state);
+      newState.addons[action.payload].isInstalling = true;
+      return newState;
+    }
+
+    case mozAppsActions.INSTALL_ERROR: {
+      /*
+        Add-on installation error.
+
+        payload (object) --
+          addonSlug (string) -- slug of add-on that failed to install.
+          errorMessage (string) -- error message from browser.
+      */
+      const newState = _.cloneDeep(state);
+      const {addonSlug, errorMessage} = action.payload;
+      newState.addons[addonSlug].installErrorMessage = errorMessage;
+      newState.addons[addonSlug].isInstalling = false;
+      return newState;
+    }
+
+    case mozAppsActions.INSTALL_OK: {
+      /*
+        Add-on installation success.
+
+        payload (string) -- slug of add-on installed.
+      */
+      const newState = _.cloneDeep(state);
+      newState.addons[action.payload].isInstalling = false;
+      newState.addons[action.payload].isInstalled = true;
       return newState;
     }
 

--- a/src/media/js/app.js
+++ b/src/media/js/app.js
@@ -12,19 +12,12 @@ import persistState from 'redux-localstorage'
 import persistSlicer from 'redux-localstorage-slicer';
 import thunkMiddleware from 'redux-thunk';
 
-import {loginRequired} from './site/login';
-
+import * as mozAppsActions from './addon/actions/mozApps';
 import AddonDashboard from './addon/containers/dashboard';
 import AddonDashboardDetail from './addon/containers/dashboardDetail';
 import AddonReview from './addon/containers/review';
 import AddonReviewDetail from './addon/containers/reviewDetail';
 import AddonSubmit from './addon/containers/submit';
-import App from './site/containers/app';
-import DeveloperAgreement from './site/containers/devAgreement';
-import Landing from './site/containers/landing';
-import Login from './site/containers/login'
-import LoginOAuthRedirect from './site/containers/loginOAuthRedirect';
-
 import addon from './addon/reducers/addon';
 import addonDashboard from './addon/reducers/dashboard';
 import addonReview from './addon/reducers/review';
@@ -33,6 +26,13 @@ import {addonSubmitReducer as
         addonSubmit,
         addonSubmitVersionReducer as
         addonSubmitVersion} from './addon/reducers/submit';
+import {ADDON_REVIEW, ADDON_SUBMIT} from './site/constants/login';
+import App from './site/containers/app';
+import DeveloperAgreement from './site/containers/devAgreement';
+import Landing from './site/containers/landing';
+import Login from './site/containers/login'
+import LoginOAuthRedirect from './site/containers/loginOAuthRedirect';
+import {loginRequired} from './site/login';
 import apiArgs from './site/reducers/apiArgs';
 import login from './site/reducers/login';
 import notification from './site/reducers/notification';
@@ -78,10 +78,13 @@ if (process.env.NODE_ENV !== 'production') {
 const createFinalStore = compose.apply(this, storeEnhancers)(createStore);
 const store = createFinalStore(reducer);
 
-const LOGIN = 'content_tools_login';
-export const ADDON_REVIEW = [LOGIN, 'content_tools_addon_review'];
-export const ADDON_SUBMIT = [LOGIN, 'content_tools_addon_submit'];
-export const CONTENT_TOOLS_LOGIN = [LOGIN];
+
+document.addEventListener('visibilitychange', () => {
+  // Refresh installed add-ons on visibility change.
+  if (!document.hidden) {
+    store.dispatch(mozAppsActions.getInstalled());
+  }
+});
 
 
 function renderRoutes() {

--- a/src/media/js/site/components/page.js
+++ b/src/media/js/site/components/page.js
@@ -59,11 +59,13 @@ export class PageSection extends React.Component {
     children: React.PropTypes.object.isRequired,
     className: React.PropTypes.string,
     title: React.PropTypes.string,
+    style: React.PropTypes.object
   };
 
   render() {
     return (
-      <section className={classnames(this.props.className, 'page-section')}>
+      <section className={classnames(this.props.className, 'page-section')}
+               style={this.props.style || {}}>
         {this.props.title && <PageSectionHeader {...this.props}/>}
         <div className="page-section--main">
           {this.props.children}

--- a/src/media/js/site/constants/login.js
+++ b/src/media/js/site/constants/login.js
@@ -1,0 +1,4 @@
+export const LOGIN = 'content_tools_login';
+export const ADDON_REVIEW = [LOGIN, 'content_tools_addon_review'];
+export const ADDON_SUBMIT = [LOGIN, 'content_tools_addon_submit'];
+export const CONTENT_TOOLS_LOGIN = [LOGIN];


### PR DESCRIPTION
- fix tests, subnav was requiring app.js
- move install-related action creators to actions/mozApps.js
- rename addon/components/addonSubnav.js to addon/components/subnav.js for consistency